### PR TITLE
fix(artifacts): prevent duplicate artifact creation

### DIFF
--- a/src/controllers/artifacts.ts
+++ b/src/controllers/artifacts.ts
@@ -11,7 +11,7 @@ export const createArtifact = (req: Request<{}, {}, CreateArtifactInput>,res: Re
   )
 
   if (existingArtifact) {
-    res.status(400).json({
+    return res.status(400).json({
       message: 'Artifact code already exists'
     })
   }


### PR DESCRIPTION
Al realizar la pruebas con el endpoint GET de /artifacts, me percate de un error en el codigo de el controllador artifacts.ts. Donde en la linea 14 que verifica el artefacto no detiene el codigo al intentar insertar otro artefacto con el mismo codigo de identifiacion del artefacto. Por tanto para prevenir la duplicacion en la creacion de artefactos decidi agregar un return en dicha linea para evitar que el codigo se siguiera ejecuntando despues del mensaje de error permitiendo la duplicacion, 