### PR TITLE
Feat/start session

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "packageManager": "pnpm@10.32.1",
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
@@ -27,6 +28,7 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.6",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
     "@types/node": "^25.5.0",
     "oxlint": "^1.56.0",
@@ -27,6 +28,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "express": "^5.2.1",
+    "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",
     "zod": "^4.3.6"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,9 @@
 import express from "express";
-import type { Request, Response, NextFunction } from "express";
 import morgan from "morgan";
+import type { Request, Response, NextFunction } from "express";
 
 import routeOne from "../src/routes/routeOne.js";
+import authRoute from "./routes/session.js"
 
 const app = express();
 
@@ -10,6 +11,7 @@ app.use(express.json())
 app.use(morgan("dev"))
 
 app.use("/api/v1", routeOne)
+app.use("/api/v1", authRoute)
 
 
 app.use((req: Request, res: Response, _next: NextFunction) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import morgan from "morgan";
+import cookieParser from "cookie-parser";
 import type { Request, Response, NextFunction } from "express";
 
 import routeOne from "../src/routes/routeOne.js";
@@ -10,6 +11,7 @@ const app = express();
 
 app.use(express.json())
 app.use(morgan("dev"))
+app.use(cookieParser())
 
 app.use("/api/v1", routeOne)
 app.use('/api/v1', artifactRoutes);

--- a/src/controllers/controllerUser.ts
+++ b/src/controllers/controllerUser.ts
@@ -3,12 +3,13 @@
 import { Request, Response } from 'express';
 import { UserCreate } from '../schemas/schemaUser.js';
 import { usersDB } from '../models/modelUser.js';
+import { hashPass } from '../utils/pass.js';
 
 const users_role = ['ADMIN', 'CIENTIFICO', 'GUERRERO'];
 
 
 
-export const createUser = (req: Request<{}, {}, UserCreate>, res: Response) => {
+export const createUser = async (req: Request<{}, {}, UserCreate>, res: Response) => {
     try {
         const { name, age, idrol, pass, authType } = req.body;
         const roleExits = users_role.includes(idrol.toUpperCase());
@@ -29,7 +30,7 @@ export const createUser = (req: Request<{}, {}, UserCreate>, res: Response) => {
             state: true,
             failed_attempts: 0,
             createdAt: new Date().toISOString(),
-            pass
+            pass: await hashPass(pass)
         };
         usersDB.push(newUser);
 

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -16,11 +16,11 @@ export const newSession = (req: Request, res: Response) => {
 
     */
 
-    const token = createSession("Admin")
+    const token = createSession("Administrador")
 
     return res.status(200).json({
       message: "Session created successfully",
-      data: "Admin",
+      data: "Administrador",
       session: token
     })
 

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from "express";
+import { createSession } from "../utils/session.js";
+
+export const newSession = (req: Request, res: Response) => {
+  try {
+    /*
+    Aquí iría la lógica para verificar las credenciales del usuario
+    const { userId, password, authHash } = req.body
+    -
+    -
+    -
+    -
+    -
+    -
+
+    */
+
+    const token = createSession("Admin")
+
+    return res.status(200).json({
+      message: "Session created successfully",
+      session: token
+    })
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error,
+    })
+  }
+}

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -1,26 +1,39 @@
 import type { Request, Response } from "express";
 import { createSession } from "../utils/session.js";
-// import type { AuthInput } from "../schemas/auth.js";
+import type { AuthInput } from "../schemas/auth.js";
+import { usersDB } from "../models/modelUser.js";
+
+import { comparePass } from "../utils/pass.js";
 
 export const newSession = async (req: Request, res: Response) => {
   try {
-    /*
-    Aquí iría la lógica para verificar las credenciales del usuario
+    // oxlint-disable-next-line no-unused-vars
     const { userId, password, authHash } = req.body as AuthInput;
-    -
-    -
-    -
-    -
-    -
-    -
 
-    */
+    const isUserExist = usersDB.find(
+      (User) => User.id === Number(userId)
+    )
 
-    const token = await createSession({ role: "Administrador" })
+    if (!isUserExist) {
+      return res.status(404).json({
+        messageError: "user not found"
+      })
+    }
+
+    const isSame = await comparePass(password, isUserExist.pass)
+
+    if (!isSame) {
+      isUserExist.failed_attempts++
+      return res.status(401).json({
+        messageError: "Invalid credentials, try again"
+      })
+    }
+
+    const token = await createSession({ role: isUserExist.idrol })
 
     return res.status(200).cookie("token", token).json({
       message: "Session created successfully",
-      data: "Administrador",
+      data: isUserExist.idrol,
       session: token
     })
 

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { createSession } from "../utils/session.js";
 // import type { AuthInput } from "../schemas/auth.js";
 
-export const newSession = (req: Request, res: Response) => {
+export const newSession = async (req: Request, res: Response) => {
   try {
     /*
     Aquí iría la lógica para verificar las credenciales del usuario
@@ -16,9 +16,9 @@ export const newSession = (req: Request, res: Response) => {
 
     */
 
-    const token = createSession("Administrador")
+    const token = await createSession({ role: "Administrador" })
 
-    return res.status(200).json({
+    return res.status(200).cookie("token", token).json({
       message: "Session created successfully",
       data: "Administrador",
       session: token

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -1,11 +1,12 @@
 import type { Request, Response } from "express";
 import { createSession } from "../utils/session.js";
+// import type { AuthInput } from "../schemas/auth.js";
 
 export const newSession = (req: Request, res: Response) => {
   try {
     /*
     Aquí iría la lógica para verificar las credenciales del usuario
-    const { userId, password, authHash } = req.body
+    const { userId, password, authHash } = req.body as AuthInput;
     -
     -
     -
@@ -19,6 +20,7 @@ export const newSession = (req: Request, res: Response) => {
 
     return res.status(200).json({
       message: "Session created successfully",
+      data: "Admin",
       session: token
     })
 

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -9,6 +9,9 @@ export const newSession = async (req: Request, res: Response) => {
   try {
     // oxlint-disable-next-line no-unused-vars
     const { userId, password, authHash } = req.body as AuthInput;
+    // userId es cambiable por email (no afecta el flujo)
+    // authHash depende del metodo de autheticacion que tenga el user
+    // al implementarlo, sigue la logica del password
 
     const isUserExist = usersDB.find(
       (User) => User.id === Number(userId)

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -2,6 +2,8 @@ import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import type { jwtPayload } from '../utils/session.js'
 
+const secret = process.env.JWT_SECRET as string
+
 //mover esta modificacion al type Required a un achivo de tipados
 declare global {
   namespace Express {
@@ -20,7 +22,7 @@ export const verifyToken = (req: Request, res: Response, next: NextFunction) => 
   }
 
   try {
-    const decoded = jwt.verify(token, 'secretHere') as jwtPayload;
+    const decoded = jwt.verify(token, secret) as jwtPayload;
     req.user = decoded;
     next();
   } catch {

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -1,17 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import type { jwtPayload } from '../utils/session.js'
+import type { jwtPayload } from '../types/index.js'
 
 const secret = process.env.JWT_SECRET as string
-
-//mover esta modificacion al type Required a un achivo de tipados
-declare global {
-  namespace Express {
-    interface Request {
-      user?: jwtPayload;
-    }
-  }
-}
 
 export const verifyToken = (req: Request, res: Response, next: NextFunction) => {
   const { token } = req.cookies

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import type { jwtPayload } from '../utils/session.js'
+
+//mover esta modificacion al type Required a un achivo de tipados
+declare global {
+  namespace Express {
+    interface Request {
+      user?: jwtPayload;
+    }
+  }
+}
+
+export const verifyToken = (req: Request, res: Response, next: NextFunction) => {
+  const { session } = req.body
+
+  if (!session) {
+    res.status(401).json({ error: "Token requerido" });
+    return;
+  }
+
+  try {
+    const decoded = jwt.verify(session, 'secretHere') as jwtPayload;
+    req.user = decoded;
+    next();
+  } catch {
+    res.status(401).json({ error: "Token inválido o expirado" });
+  }
+};
+
+export const verifyRole = (...roles: string[]) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      res.status(401).json({ error: "No autenticado" });
+      return;
+    }
+
+    if (!roles.includes(req.user.role)) {
+      res.status(403).json({ error: "No tenés permiso para este recurso" });
+      return;
+    }
+
+    next();
+  };
+};

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -12,15 +12,15 @@ declare global {
 }
 
 export const verifyToken = (req: Request, res: Response, next: NextFunction) => {
-  const { session } = req.body
+  const { token } = req.cookies
 
-  if (!session) {
+  if (!token) {
     res.status(401).json({ error: "Token requerido" });
     return;
   }
 
   try {
-    const decoded = jwt.verify(session, 'secretHere') as jwtPayload;
+    const decoded = jwt.verify(token, 'secretHere') as jwtPayload;
     req.user = decoded;
     next();
   } catch {

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { newSession } from "../controllers/session.js";
+
+const router: Router = Router();
+
+router.post("/auth/login", newSession);
+
+export default router;

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { newSession } from "../controllers/session.js";
+import { verifyData } from "../middlewares/verifyData.js"
+import { authSchema } from "../schemas/auth.js";
 
 const router: Router = Router();
 
-router.post("/auth/login", newSession);
+router.post("/auth/login", verifyData(authSchema), newSession);
 
 export default router;

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,0 +1,9 @@
+import z from "zod";
+
+export const authSchema = z.strictObject({
+  userId: z.string().min(1, "User ID is required"),
+  password: z.string().min(8, "Password must be at least 8 characters long"),
+  authHash: z.string().min(1, "Auth hash is required")
+})
+
+export type AuthInput = z.infer<typeof authSchema>;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,9 @@
+import { jwtPayload } from './index.ts'
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: jwtPayload;
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+//mover el type jwtPayload a un achivo de tipados
+export type jwtPayload = {
+  role:string
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,9 +1,5 @@
 import jwt from 'jsonwebtoken';
-
-//mover el type jwtPayload a un achivo de tipados
-export type jwtPayload = {
-  role:string
-}
+import type { jwtPayload } from '../types/index.js'
 
 const secret = process.env.JWT_SECRET as string
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,7 +1,12 @@
 import jwt from 'jsonwebtoken';
 
+//mover el type jwtPayload a un achivo de tipados
+export type jwtPayload = {
+  role:string
+}
+
 export  function createSession(userRole: string): string {
-  const payload = {
+  const payload: jwtPayload = {
     role: userRole,
   }
   const token = jwt.sign(payload, "secretHere", {

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -5,12 +5,12 @@ export type jwtPayload = {
   role:string
 }
 
-export  function createSession(userRole: string): string {
-  const payload: jwtPayload = {
-    role: userRole,
-  }
-  const token = jwt.sign(payload, "secretHere", {
-    expiresIn: '1h',
-  });
-  return token;
-}
+// oxlint-disable-next-line require-await
+export async function createSession (payload: jwtPayload): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    jwt.sign(payload, 'secretHere', (err, token) => {
+      if (err) reject(err)
+      resolve(token as string)
+    })
+  })
+} 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,11 @@
+import jwt from 'jsonwebtoken';
+
+export  function createSession(userRole: string): string {
+  const payload = {
+    role: userRole,
+  }
+  const token = jwt.sign(payload, "secretHere", {
+    expiresIn: '1h',
+  });
+  return token;
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -5,10 +5,12 @@ export type jwtPayload = {
   role:string
 }
 
+const secret = process.env.JWT_SECRET as string
+
 // oxlint-disable-next-line require-await
 export async function createSession (payload: jwtPayload): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    jwt.sign(payload, 'secretHere', (err, token) => {
+    jwt.sign(payload, secret , (err, token) => {
       if (err) reject(err)
       resolve(token as string)
     })


### PR DESCRIPTION
En esta pull, se desarrollo el inicio de session donde se retorna una cookie llamada **token** que almacena el payload de JWT que se usara para las posteriores autenticaciones y autorizaciones en las rutas de la API.

> [!IMPORTANT]
> se debe agregar al archivo de variables de entorno la siguiente variable
> ```env
> PORT=<puerto numerico donde corre la app
>JWT_SECRET=<cualquier string que quieran>
>```

para esto, se creo los archivos **_controller/session.ts, routes/session.ts, schema/session.ts_** y los middlewares **_verifyToken y verifyToken_** para verificar que el usado no haya sido modificado o haya expirado y que dependiendo del recurso a solicitar tenga el rol necesario para acceder.

para probarlo, se debe mandar a la ruta **_POST /user_** el body (proporcionado por @RodriKonrad)
```json
{
  "name": "Marina Hernandez",
  "age": 30,
  "idrol": "ADMIN",
  "pass": "12345678",
  "authType": "DNA_HUMAN"
}
```

una vez confirmada la creacion del user, mandamos la solicitud **_POST /auth/login_** 
```json
{
  "userId": "1",
  "password": "12345678",
  "authHash": "<momentáneamente cualquier string vale>"
}
```
