### PR TITLE
Feat/close session

### DIFF
--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -46,3 +46,15 @@ export const newSession = async (req: Request, res: Response) => {
     })
   }
 }
+
+export const closeSession = (req: Request, res: Response) => {
+  try {
+    res.clearCookie("token").json({
+      message: "Session closed successfully"
+    })
+  } catch (error) {
+    return res.status(500).json({
+      message: error,
+    })
+  }
+}

--- a/src/controllers/session.ts
+++ b/src/controllers/session.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { createSession } from "../utils/session.js";
+import { createSession, addToBlacklist } from "../utils/session.js";
 import type { AuthInput } from "../schemas/auth.js";
 import { usersDB } from "../models/modelUser.js";
 
@@ -49,6 +49,11 @@ export const newSession = async (req: Request, res: Response) => {
 
 export const closeSession = (req: Request, res: Response) => {
   try {
+
+    const { token } = req.cookies
+
+    addToBlacklist(token)
+    
     res.clearCookie("token").json({
       message: "Session closed successfully"
     })

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import type { jwtPayload } from '../types/index.js'
+import { isBlacklisted } from '../utils/session.js'
 
 const secret = process.env.JWT_SECRET as string
 
@@ -9,6 +10,11 @@ export const verifyToken = (req: Request, res: Response, next: NextFunction) => 
 
   if (!token) {
     res.status(401).json({ error: "Token requerido" });
+    return;
+  }
+
+  if (isBlacklisted(token)) {
+    res.status(401).json({ error: "Token inválido o expirado" });
     return;
   }
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -11,4 +11,14 @@ export async function createSession (payload: jwtPayload): Promise<unknown> {
       resolve(token as string)
     })
   })
-} 
+}
+
+const blackList = new Set<string>()
+
+export function addToBlacklist(token: string): void {
+  blackList.add(token)
+}
+
+export function isBlacklisted(token: string): boolean {
+  return blackList.has(token)
+}


### PR DESCRIPTION
Para completar el ciclo de sesión, se implementó el cierre de sesión donde
1. Se **_elimina la cookie que contiene el token de session_** que permite el uso del sistema
2. El token eliminado **_es almacenado en una lista negra _**, ya que el token tiene un tiempo de vida util que no se puede modificar o destruir durante ese tiempo
3. Si un usuario intenta iniciar con ese token después de haber cerrado sesión estando aun en su vida util, se le niega el acceso (dado que ya fue usado y no se usará más).
