### PR TITLE
refactor(artifacts): update artifact schemas and controller to match new variables

### DIFF
--- a/src/controllers/artifacts.ts
+++ b/src/controllers/artifacts.ts
@@ -3,12 +3,11 @@ import { Request, Response } from 'express';
 import { CreateArtifactInput, PatchArtifactInput } from '../schemas/artifacts.js';
 import { artifactInventory, Artifact } from '../models/artifacts.js';
 
+
 // oxlint-disable-next-line typescript/ban-types
 export const createArtifact = (req: Request<{}, {}, CreateArtifactInput>,res: Response) => {
   const artifactData = req.body;
-  const existingArtifact = artifactInventory.find(
-    (artifact) => artifact.code === artifactData.code
-  )
+  const existingArtifact = null
 
   if (existingArtifact) {
     return res.status(400).json({
@@ -18,6 +17,7 @@ export const createArtifact = (req: Request<{}, {}, CreateArtifactInput>,res: Re
 
   const newArtifact: Artifact = {
     id: crypto.randomUUID(),
+    state: true,
     ...artifactData
   }
 
@@ -43,7 +43,7 @@ export const patchArtifacts = (  req: Request<{ id: string }, {}, PatchArtifactI
     (artifact) => artifact.id === id
   );
 
-  if (artifactIndex === -1){
+  if (artifactIndex == -1){
     return res.status(404).json({message: 'Artifact not found'})
   }
 

--- a/src/models/artifacts.ts
+++ b/src/models/artifacts.ts
@@ -2,6 +2,7 @@ import { CreateArtifactInput } from '../schemas/artifacts.js';
 //Temporal, solo pruebas
 export interface Artifact extends CreateArtifactInput {
   id: string;
+  state: boolean;
 }
 
 export const artifactInventory: Artifact[] = [];

--- a/src/schemas/artifacts.ts
+++ b/src/schemas/artifacts.ts
@@ -13,9 +13,13 @@ export const originEnum = z.enum([
   'NAMEKIANO'
 ]);
 
-export const dangerLevelEnum = z.enum(['High', 'Mid', 'Low']);
-
-export const stateEnum = z.enum(['Activo', 'Inactivo']);
+export const dangerLevelEnum = z.union([  
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5)
+]);
 
 export const confidentialityEnum = z.enum([
   'Public',
@@ -25,28 +29,28 @@ export const confidentialityEnum = z.enum([
 ]);
 
 export const createArtifactSchema = z.object({
-  code: z.string().min(1, 'Code is required'),
-  name: z.string().min(1, 'Name is required'),
-  description: z.string().min(1, 'Description is required'),
-  createdAt: z.string().min(1, 'Creation date is required'),
-  artifactType: z.string().min(1, 'Artifact type is required'),
-  category: categoryEnum,
-  origin: originEnum,
-  inventor: z.string().min(1, 'Inventor is required'),
-  dangerLevel: dangerLevelEnum,
-  confidentialityLevel: confidentialityEnum,
-  state: stateEnum
+  nombre_Artefacto: z.string().min(1, 'Name is required'),
+  descripcion: z.string().min(1, 'Description is required'),
+  fecha_creacion: z.string().regex(
+    /^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/,
+    "Formato debe ser dd/mm/yyyy").min(1, 'Creation date is required'),
+  id_tipo: z.string().min(1, 'Artifact type is required'),
+  id_categoria: categoryEnum,
+  origen: originEnum,
+  id_usuario: z.string().min(1, 'Inventor is required'),
+  nivel_peligrosidad: dangerLevelEnum,
+  confidentialityLevel: confidentialityEnum
 });
 
 export type CreateArtifactInput = z.infer<typeof createArtifactSchema>;
 
 export const patchArtifactSchema = createArtifactSchema
   .pick({
-    name: true,
-    description: true,
-    category: true,
-    origin: true,
-    dangerLevel: true
+    nombre_Artefacto: true,
+    descripcion: true,
+    id_categoria: true,
+    origen: true,
+    nivel_peligrosidad: true
   })
   .partial()
   .refine((data) => Object.keys(data).length > 0, {


### PR DESCRIPTION
Se realizaron los cambios de nombre a cada dato del schema como se habia previsto. La variable state fue movida a el modelo de artefactos y cambiada a tipo boolean como se especifico anteriormente.
## Importante
Debido a los cambios en el schema la funcionalidad encargada de verificar los codigos de los artefactos en el contolador queda temporalmente desabilitada, hasta realizar el empalme con la bd real.