### PR TITLE
feat(app): implement cors package and use on app file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
     "@types/cookie-parser": "^1.4.10",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
@@ -29,6 +30,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.6",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import morgan from "morgan";
 import cookieParser from "cookie-parser";
+import cors from "cors";
 import type { Request, Response, NextFunction } from "express";
 
 import userRoute from "./routes/userRoute.js";
@@ -13,6 +14,13 @@ const app = express();
 app.use(express.json())
 app.use(morgan("dev"))
 app.use(cookieParser())
+app.use(cors({
+  origin: '*',
+  methods: 'GET, POST, PUT, PATCH, DELETE',
+  preflightContinue: true,
+  optionsSuccessStatus: 204,
+  credentials: true
+}))
 
 app.use('/api/v1', artifactRoutes);
 app.use('/api/v1', userRoute);


### PR DESCRIPTION
Janie me hizo caer en cuenta de que, la API no esta reconociendo los orígenes diferentes al a la dirección de la API esta la bloquea por no tener el mismo origen.

Es por esto que se una la librería **_CORS_** que nos permite configurar esta característica y solucionar este problema

